### PR TITLE
feat: Added hide_stroke option

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -19,6 +19,7 @@ export type UiConfig = {
   Format: string;
   hiddenItems: string | undefined;
   showItems: string | undefined;
+  hideStroke: boolean | string;
 };
 
 export default async function readmeStats(req: any, res: any): Promise<any> {
@@ -44,6 +45,7 @@ export default async function readmeStats(req: any, res: any): Promise<any> {
       Format: req.query.format || "svg",
       hiddenItems: req.query.hide,
       showItems: req.query.show,
+      hideStroke: parseBoolean(req.query.hide_stroke) || false,
     };
 
     if (!username) {

--- a/src/card.ts
+++ b/src/card.ts
@@ -24,6 +24,7 @@ export default function cardStyle(data: GetData, uiConfig: UiConfig): string {
   const userYAngle = isDisabledAnimations ? 140 : 130;
   const follXAngle = isDisabledAnimations ? 120 : 110;
   const follYAngle = isDisabledAnimations ? 161 : 151;
+  const hideStroke = parseBoolean(uiConfig.hideStroke) ? `` : `stroke="#${uiConfig.strokeColor}" stroke-width="5"`;
   const animations = parseBoolean(uiConfig.disabledAnimations || uiConfig.Format === "png") ? `` : `        /* Animations */
         @keyframes scaleInAnimation {
             from {
@@ -190,7 +191,7 @@ export default function cardStyle(data: GetData, uiConfig: UiConfig): string {
                     <image x="0%" y="0%" width="512" height="512" href="data:image/jpeg;base64,${data.pic}"></image>
                 </pattern>
             </defs>
-            <circle cx="${imageXAngle}" cy="${imageYAngle}" r="50" fill="url(#image)" stroke="#${uiConfig.strokeColor}" stroke-width="5"/>
+            <circle cx="${imageXAngle}" cy="${imageYAngle}" r="50" fill="url(#image)" ${hideStroke}/>
         </g>
         <text x="${userXAngle}" y="${userYAngle}" direction="ltr" class="text-username div-animation">@${data.username}</text>
         <g class="div-animation text-middle">


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->

Added `hide_stroke` option. This option hide stroke in the image profile if value is true.

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [x] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/FajarKim/github-readme-profile/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
![image](https://github-readme-profile-hbtt6de22-fajarkim.vercel.app/api?username=FajarKim&hide_stroke=true)