### PR TITLE
feat(theme): Added github_dark_highcontrast and github_light_highcontrast themes

### DIFF
--- a/themes/index.ts
+++ b/themes/index.ts
@@ -94,6 +94,14 @@ export const themes: Themes = {
     bg_color: "161B22",
     border_color: "3FB950",
   },
+  github_dark_highcontrast: {
+    title_color: "409EFE",
+    icon_color: "2EA043",
+    text_color: "FFFFFF",
+    bg_color: "0A0C10",
+    border_color: "FFFFFF",
+    stroke_color: "2EA043",
+  },
   github_dark_dimmed: {
     title_color: "316ECB",
     icon_color: "57AB5A",
@@ -107,6 +115,14 @@ export const themes: Themes = {
     text_color: "1F2227",
     bg_color: "FFFFFF",
     border_color: "34D058",
+  },
+  github_light_highcontrast: {
+    title_color: "0249B3",
+    icon_color: "055D20",
+    text_color: "0E1116",
+    bg_color: "FFFFFF",
+    border_color: "272B34",
+    stroke_color: "055D20",
   },
   "whatsapp-light": {
     title_color: "1DAB61",


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->

Added `github_dark_highcontrast` and `github_light_highcontrast` themes.

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [x] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Misc change (updated other files non-breaking change)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/FajarKim/github-readme-profile/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked this code with command `npm run build`
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
- Github_light_highcontrast theme preview

![image](https://gh-readme-profile.vercel.app/api?username=xaviernotfound&bg_color=FFFFFF&title_color=0249B3&text_color=24292F&icon_color=055D20&border_color=24292F&stroke_color=055D20)
- Github_dark_highcontrast theme preview

![image](https://gh-readme-profile.vercel.app/api?username=xaviernotfound&bg_color=0A0C10&title_color=409EFE&text_color=FFFFFF&icon_color=2EA043&border_color=FFFFFF&stroke_color=2EA043)