### PR TITLE
feat(theme): Added github_dark_tritanopia and github_light_tritanopia themes

### DIFF
--- a/themes/index.ts
+++ b/themes/index.ts
@@ -109,6 +109,14 @@ export const themes: Themes = {
     bg_color: "21262D",
     border_color: "57AB5A",
   },
+  github_dark_tritanopia: {
+    title_color: "1F6FEA",
+    icon_color: "1585FD",
+    text_color: "F1F6FC",
+    bg_color: "161B22",
+    border_color: "484F58",
+    stroke_color: "FA4549",
+  },
   github_light: {
     title_color: "0969DA",
     icon_color: "34D058",
@@ -123,6 +131,14 @@ export const themes: Themes = {
     bg_color: "FFFFFF",
     border_color: "272B34",
     stroke_color: "055D20",
+  },
+  github_light_tritanopia: {
+    title_color: "0969DA",
+    icon_color: "0088FF",
+    text_color: "24292F",
+    bg_color: "FFFFFF",
+    border_color: "D1D5DA",
+    stroke_color: "FA4549",
   },
   "whatsapp-light": {
     title_color: "1DAB61",


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->

Added `github_dark_tritanopia` and `github_light_tritanopia` themes.

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [x] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Misc change (updated other files non-breaking change)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/FajarKim/github-readme-profile/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked this code with command `npm run build`
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
- Github_dark_tritanopia theme preview

![image](https://gh-readme-profile.vercel.app/api?username=xaviernotfound&bg_color=161B22&title_color=1F6FEA&text_color=F1F6FC&icon_color=1585FD&border_color=484F58&stroke_color=FA4549)
- Github_light_tritanopia theme preview

![image](https://gh-readme-profile.vercel.app/api?username=xaviernotfound&bg_color=FFFFFF&title_color=0969DA&text_color=24292F&icon_color=0088FF&border_color=D1D5DA&stroke_color=FA4549)