### PR TITLE
feat(theme): Added bluloco and bluloco-dark themes

### DIFF
--- a/themes/index.ts
+++ b/themes/index.ts
@@ -396,6 +396,20 @@ export const themes: Themes = {
     bg_color: "484848",
     stroke_color: "41363c",
   },
+  bluloco: {
+    title_color: "275fe4",
+    text_color: "df621b",
+    icon_color: "239749",
+    border_color: "ECEDEE",
+    bg_color: "F9F9F9",
+  },
+  "bluloco-dark": {
+    title_color: "3375fe",
+    text_color: "cdd3e0",
+    icon_color: "25a45c",
+    border_color: "21242D",
+    bg_color: "282C34",
+  },
 
   // Gradient themes
   "sunset-gradient": {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->

Added `bluloco` and `bluloco-dark` themes. This theme inspired from <https://github.com/uloco/bluloco.nvim>.

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [x] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Misc change (updated other files non-breaking change)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `npm test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/FajarKim/github-readme-profile/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
- `bluloco` theme preview:

![image](https://gh-readme-profile.vercel.app/api?username=FajarKim&title_color=275fe4&text_color=df621b&icon_color=239749&border_color=ECEDEE&bg_color=F9F9F9)
- `bluloco-dark` theme preview:

![image](https://gh-readme-profile.vercel.app/api?username=FajarKim&title_color=3375fe&text_color=ff9369&icon_color=25a45c&border_color=21242D&bg_color=282C34)