### PR TITLE
feat(theme): Added kanagawa and kanagawa_light themes

### DIFF
--- a/themes/index.ts
+++ b/themes/index.ts
@@ -472,6 +472,20 @@ export const themes: Themes = {
     bg_color: "402b23",
     stroke_color: "bf4a3f",
   },
+  kanagawa: {
+    title_color: "E82424",
+    text_color: "DCD7BA",
+    icon_color: "938AA9",
+    border_color: "393836",
+    bg_color: "1F1F28",
+  },
+  kanagawa_light: {
+    title_color: "d7474b",
+    text_color: "1F1F28",
+    icon_color: "624c83",
+    border_color: "d5cea3",
+    bg_color: "f2ecbc",
+  },
 
   // Gradient themes
   "sunset-gradient": {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->

This themes inspired from <https://github.com/rebelot/kanagawa.nvim>.

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [x] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Misc change (updated other files non-breaking change)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `npm test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/FajarKim/github-readme-profile/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
- `kanagawa` theme preview

![image](https://gh-readme-profile.vercel.app/api?username=FajarKim&title_color=E82424&text_color=DCD7BA&icon_color=938AA9&bg_color=1F1F28&border_color=393836)
- `kanagawa_light` theme preview

![image](https://gh-readme-profile.vercel.app/api?username=FajarKim&title_color=d7474b&text_color=1F1F28&icon_color=624c83&border_color=d5cea3&bg_color=f2ecbc)