### PR TITLE
feat: add `lavender_breeze` and `lavender_dream` themes

### DIFF
--- a/themes/index.ts
+++ b/themes/index.ts
@@ -515,6 +515,22 @@ const themes: Themes = {
     border_color: "fbf8ef",
     bg_color: "efeae9",
   },
+  lavender_breeze: {
+    title_color: "a99e68",
+    text_color: "ab788e",
+    icon_color: "a99e68",
+    border_color: "d8c4f4",
+    username_color: "a99e68",
+    bg_color: "eee7fd",
+  },
+  lavender_dream: {
+    title_color: "e6d9a2",
+    text_color: "d687b4",
+    icon_color: "e6d9a2",
+    border_color: "6b518d",
+    username_color: "e6d9a2",
+    bg_color: "4a3b66",
+  },
 
   // Gradient themes
   "sunset-gradient": {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->

Added new themes `lavender_breeze` and `lavender_dream`.

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [x] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Misc change (updated other files non-breaking change)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `npm test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/FajarKim/github-readme-profile/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->

- **Lavender Breeze**

![Lavender Breeze](https://gh-readme-profile.vercel.app/api?username=FajarKim&bg_color=EEE7FD&title_color=A99E68&text_color=AB788E&icon_color=A99E68&border_color=D8C4F4&username_color=A99E68)

- **Lavender Dream**

![Lavender Dream](https://gh-readme-profile.vercel.app/api?username=FajarKim&bg_color=4A3B66&title_color=e6d9a2&text_color=D687B4&icon_color=e6d9a2&border_color=6B518D&username_color=e6d9a2)