### PR TITLE
feat: add `monochrome-light` and `monochrome-dark` gradient themes

### DIFF
--- a/themes/index.ts
+++ b/themes/index.ts
@@ -566,6 +566,20 @@ const themes: Themes = {
     icon_color: "EFFA4B",
     bg_color: "50,4A1133,0B1133",
   },
+  "monochrome-light-gradient": {
+    title_color: "000000",
+    text_color: "000000",
+    icon_color: "49494b",
+    border_color: "e1d9d9",
+    bg_color: "4,f0f0f0,dfdbdb",
+  },
+  "monochrome-dark-gradient": {
+    title_color: "ffffff",
+    text_color: "ffffff",
+    icon_color: "e1d9d9",
+    border_color: "444242",
+    bg_color: "4,1d1d1e,4a4a4a",
+  },
 };
 
 export { Themes, themes };


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->

Added new gradient themes, `monochrome-light-gradient` and `monochrome-dark-gradient`

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [x] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Misc change (updated other files non-breaking change)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `npm test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/FajarKim/github-readme-profile/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->

- **Monochrome Light Gradient**

![Monochrome Light](https://gh-readme-profile.vercel.app/api?username=FajarKim&title_color=000&text_color=000&icon_color=49494b&border_color=e1d9d9&bg_color=4,f0f0f0,dfdbdb)

- **Monochrome Dark Gradient**

![Monochrome Dark](https://gh-readme-profile.vercel.app/api?username=FajarKim&title_color=fff&text_color=fff&icon_color=e1d9d9&border_color=444242&bg_color=4,1d1d1e,4a4a4a)