### PR TITLE
feat: add new option `photo_resize`

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -27,6 +27,7 @@ import { isValidHexColor, isValidGradient } from "../src/common/utils";
  * @property {boolean|string} hideStroke - Toggle for hiding strokes.
  * @property {boolean|string} hideBorder - Toggle for hiding borders.
  * @property {number|string} photoQuality - Photo image quality.
+ * @property {number|string} photoResize - Photo image resize.
  */
 type UiConfig = {
   titleColor: string;
@@ -46,6 +47,7 @@ type UiConfig = {
   hideStroke: boolean | string;
   hideBorder: boolean | string;
   photoQuality: number | string;
+  photoResize: number | string;
 };
 
 /**
@@ -59,6 +61,7 @@ async function readmeStats(req: any, res: any): Promise<any> {
   try {
     const username = escapeHTML(req.query.username);
     const photoQuality = Math.max(0, Math.min(parseInt(escapeHTML(req.query.photo_quality || "15")), 100));
+    const photoResize = Math.max(10, parseInt(escapeHTML(req.query.photo_resize || "150")));
 
     const fallbackTheme = "default";
     const defaultTheme: Themes[keyof Themes] = themes[fallbackTheme];
@@ -82,6 +85,7 @@ async function readmeStats(req: any, res: any): Promise<any> {
       hideStroke: parseBoolean(escapeHTML(req.query.hide_stroke)) || false,
       hideBorder: parseBoolean(escapeHTML(req.query.hide_border)) || false,
       photoQuality: photoQuality,
+      photoResize: photoResize,
     };
 
     if (!username) {

--- a/src/card.ts
+++ b/src/card.ts
@@ -22,8 +22,11 @@ async function card(data: GetData, uiConfig: UiConfig): Promise<string> {
   const photoQuality = typeof uiConfig.photoQuality === "string"
     ? parseInt(uiConfig.photoQuality, 10)
     : uiConfig.photoQuality;
+  const photoResize = typeof uiConfig.photoResize === "string"
+    ? parseInt(uiConfig.photoResize, 10)
+    : uiConfig.photoResize;
   const outputBuffer = await sharp(imageBuffer)
-    .resize({ width: 150 })
+    .resize({ width: photoResize })
     .jpeg({ quality: photoQuality })
     .toBuffer();
   const dataPicture = outputBuffer.toString("base64");

--- a/tests/card.test.ts
+++ b/tests/card.test.ts
@@ -40,6 +40,7 @@ describe("Test card function", () => {
     showItems: "reviews,issues_closed",
     hiddenItems: "forks,commits",
     photoQuality: 15,
+    photoResize: 150,
   };
 
   it("should generate SVG markup with default values", async () => {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->

Add new option `photo_resize`. This option set custom size the photo profile.

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [x] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Misc change (updated other files non-breaking change)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `npm test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/FajarKim/github-readme-profile/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
_No screenshots_