### PR TITLE
fix(middleware): exclude `/themes` and `/i18n` from proxy

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,7 @@
 // Configuration for Vercel Edge Middleware (same as original)
 export const config = {
-  // Matcher: all paths except those starting with /api
-  matcher: ['/((?!api/).*)'],
+  // Matcher: all paths except those starting with '/api', '/themes', and '/i18n'
+  matcher: ['/((?!api/|themes/|i18n/).*)'],
 };
 
 export default async function middleware(request: Request): Promise<Response | void> {

--- a/middleware.ts
+++ b/middleware.ts
@@ -8,8 +8,12 @@ export default async function middleware(request: Request): Promise<Response | v
   const url = new URL(request.url);
   const { pathname, search } = url;
 
-  // Additional check to ensure /api paths don't pass through
-  if (pathname.startsWith('/api')) {
+  // Excludes paths that should be taken from the API project (not rewritten)
+  if (
+    pathname.startsWith('/api') ||
+    pathname.startsWith('/themes/') ||
+    pathname.startsWith('/i18n/')
+  ) {
     return; // let the request proceed to the serverless function
   }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->

This PR updates the middleware to exclude `/themes` and `/i18n` paths from being proxied to the external generator. Previously, only `/api` was excluded, causing unintended proxying of theme and i18n assets. This change ensures that local assets and routes under these paths are served correctly.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Misc change (updated other files non-breaking change)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `npm test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/FajarKim/github-readme-profile/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->

_None_