### PR TITLE
refactor(themes): group themes into solid and gradient categories

### DIFF
--- a/themes/index.ts
+++ b/themes/index.ts
@@ -23,12 +23,11 @@ type Themes = {
 };
 
 /**
- * Themes object stores theme collection for the card.
+ * List of solid themes collection for the card.
  *
  * @type {Themes}
  */
-const themes: Themes = {
-  // Solid themes
+const solidThemes: Themes = {
   default: {
     title_color: "2f80ed",
     text_color: "434d58",
@@ -530,9 +529,15 @@ const themes: Themes = {
     border_color: "6b518d",
     username_color: "e6d9a2",
     bg_color: "4a3b66",
-  },
+  }
+};
 
-  // Gradient themes
+/**
+ * List of gradient themes collection for the card.
+ *
+ * @type {Themes}
+ */
+const gradientThemes: Themes = {
   "sunset-gradient": {
     title_color: "FFFFFF",
     text_color: "FFFFFF",
@@ -594,8 +599,15 @@ const themes: Themes = {
     icon_color: "bbafd9",
     border_color: "8c7bbf",
     bg_color: "20,6441a5,2a0845",
-  },
+  }
 };
 
-export { Themes, themes };
+/**
+ * Themes object stores theme collection for the card.
+ *
+ * @type {Themes}
+ */
+const themes: Themes = { ...solidThemes, ...gradientThemes };
+
+export { Themes, solidThemes, gradientThemes, themes };
 export default themes;


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->

Create a new variable to group solid themes and gradient themes separately.

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Misc change (updated other files non-breaking change)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `npm test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/FajarKim/github-readme-profile/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
_None_