### PR TITLE
chore: remove `always-auth` from `.npmrc` to suppress warnings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
 @fajarkim:registry=https://npm.pkg.github.com
-always-auth=true


### PR DESCRIPTION
_No description_