### PR TITLE
docs: delete manual typescript install step in Vercel "Build & Output Settings"

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ If your language is missing, you can contribute a new translation by following t
 This project is open-source and distributed under the MIT License. You are free to use, modify, and distribute it, subject to the terms of the license. For more details, see the [`LICENSE`](./LICENSE) file.
 
 ## Deploy on Vercel
-You can host your own instance of the GitHub Readme Profile API on Vercel. This gives you full control over the endpoint and allows you to customize the behavior or add new features.
+You can host your own instance of the GitHub Readme Profile on Vercel. This gives you full control over the endpoint and allows you to customize the behavior or add new features.
 
 1. **Sign up / log in** at [vercel.com](https://vercel.com) using your GitHub account.
 2. **Fork** this repository to your GitHub account.
@@ -358,7 +358,6 @@ You can host your own instance of the GitHub Readme Profile API on Vercel. This 
    - Click “Add New…” → “Project”.
    - Import your forked repository.
    - Add an environment variable named `GH_TOKEN` with your personal access token as its value.
-   - In the **Build & Output Settings**, enable the install command and add `npm install typescript` (this ensures TypeScript dependencies are installed).
 5. **Deploy** – Vercel will automatically build and deploy your instance. Once finished, you will get a unique URL (e.g., `https://your-project.vercel.app`) that you can use in place of `gh-readme-profile.vercel.app`.
 
 [![Deploy](https://raw.githubusercontent.com/FajarKim/FajarKim/master/images/deploy-on-vercel.svg)](https://vercel.com/import/project?template=https://github.com/FajarKim/github-readme-profile)


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->

Remove the manual step in the "Deploy on Vercel" section of `README.md` that asks users to add the `npm install typescript` command to "Build & Output Settings".

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [x] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Misc change (updated other files non-breaking change)

## How Has This Been Tested?

<!--
If you have changed a feature of the stats cards, please describe the tests you made to verify your changes.
Changes strictly related to documentation can skip this section.
-->

- [x] Tested locally with a valid username
- [x] Tested locally with an invalid username
- [x] Ran tests with `npm test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other [pull requests](https://github.com/FajarKim/github-readme-profile/pulls?q=is%3Apr+sort%3Aupdated-desc+) are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
_None_